### PR TITLE
Noticed Paths

### DIFF
--- a/areas.wotw
+++ b/areas.wotw
@@ -10253,6 +10253,7 @@ anchor EastPools.CentralRoom at -1485, -4148:  # The room where you meet Kwolok 
       Bash, Grenade=1, Spear=1 OR Blaze=1
       Bash, Sword  # hover to reach the lantern, extend bash glide with upslash then hover again
       DoubleJump, Glide
+      SentryJump=1
 
   conn UpperPools.KeystoneRoomEntrance:
     moki:

--- a/areas.wotw
+++ b/areas.wotw
@@ -2729,6 +2729,13 @@ anchor EastHollow.Kwolok at 177, -4215:  # Between Ku and Kwolok
       Water, Grapple, DoubleJump  # Cancel grapple with djump
       Water, DoubleJump, TripleJump
       Water, WaterDash, Dash, Damage=10  # coyote jump from the ledge under the grappable plant
+      Water, SwordSJump=1  # probably doable with hammer as well, but it's much harder
+      # Dirty Swims, probably incomplete. Stand in shallow water on the side of the first air pocket to regen. Teleport out after breaking the wall.
+      WaterDash, Damage=60, Damage=110, Launch
+      WaterDash, Damage=60, Damage=110, Grapple, Sentry=3 OR DoubleJump OR Dash
+      WaterDash, Damage=60, Damage=110, DoubleJump, TripleJump
+      WaterDash, Damage=60, Damage=110, SwordSJump=1
+      WaterDash, Damage=60, Damage=110, Damage=20, Grapple, Sword  # extra damage from the balloon, regen spot below the grapple plant
       # Water, Grapple, SwordSJump=1                       # standing on the ledge below grapple plant. Holding right during SJump. Swordcombo to go right. Lure balloon into water first
       # Water, Grapple, SwordSJump=1, DoubleJump OR Glide  # standing on the ledge below grapple plant. Holding right during SJump
 # checkpoint at -8, -4327

--- a/areas.wotw
+++ b/areas.wotw
@@ -10275,6 +10275,7 @@ anchor EastPools.CentralRoom at -1485, -4148:  # The room where you meet Kwolok 
       EastPools.CentralRoomBubbleFree, Bash, Grenade=1  # bashnade from the seed to jump on the bubble then wait another bubble
       EastPools.CentralRoomBubbleFree, SentryJump=1  # sjump from GrassSeed
       EastPools.CentralRoomBubbleFree, GrenadeJump, DoubleJump OR Glide  # grenade jump on the bubble, use the other ability to stall, repeat until at the top
+      EastPools.CentralRoomBubbleFree, PauseHover  # Pause float spam is just barely enough stall to gain height. This is just as much fun as it sounds.
       SentryJump=2  # sjump to GrassSeed, sjump from GrassSeed
   conn WestPools:
     moki: Water, WaterBreath, WaterDash, DoubleJump OR Dash OR Glide OR Launch

--- a/areas.wotw
+++ b/areas.wotw
@@ -3709,6 +3709,8 @@ anchor WestGlades.LowerPool at -642, -4112:  # The left edge of the lower pool i
       Grapple, Spear=1 OR Blaze=1 OR Damage=20
       Bash, Glide, SwordSJump=1
       DoubleJump, TripleJump, Glide OR Sword OR Hammer OR Damage=10 OR Shuriken=2 OR Sentry=2
+      GrenadeJump, DoubleJump OR Dash OR SentryJump=1 OR Damage=10
+      SentryJump=2
   pickup WestGlades.SwimEC:
     moki: Water
     kii:

--- a/areas.wotw
+++ b/areas.wotw
@@ -2826,7 +2826,7 @@ anchor GladesTown.Teleporter at -307, -4153:  # The glades teleporter
       DoubleJump, TripleJump, Glide OR Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe, GladesTown.ClearThorns:
       GrenadeJump
-      DoubleJump, TripleJump
+      DoubleJump, TripleJump OR Dash
   pickup GladesTown.LupoSwimMiddleEX:
     moki: Water, WaterDash OR Launch
     gorlek: Water, DoubleJump
@@ -2869,9 +2869,10 @@ anchor GladesTown.Teleporter at -307, -4153:  # The glades teleporter
         SentryJump=1
         TuleyShop.Lightcatchers, Bash
     unsafe:
-      SwordSJump=2  # Midair Sentry Jumps
+      SentryJump=2  # from directly below the bridge
       TuleyShop.Lightcatchers, Bash, Grenade=1, Grapple  # grenadebash
       DoubleJump, TripleJump  # hardcore parkour
+      GladesTown.ClearThorns, DoubleJump, Dash  # hardcore parkour 2
   conn GladesTown.BellowBountyShard:
     moki:
       Launch

--- a/areas.wotw
+++ b/areas.wotw
@@ -11885,6 +11885,7 @@ anchor UpperWastes.MissilePuzzleRight at 2058, -3813:  # On top of sand to the r
     moki: UpperWastes.LeverDoor, Burrow
 
 # checkpoint at 2037, -3751
+# Should there be an anchor here?
 
 anchor UpperWastes.RuinsApproach at 2002, -3698:  # checkpoint after the laser spinner
   refill Checkpoint
@@ -11914,6 +11915,7 @@ anchor UpperWastes.RuinsApproach at 2002, -3698:  # checkpoint after the laser s
     unsafe:
       Burrow, Bash  # Bash the Mantis to reach the wall under the pickup, then get a weird boost on the wall after abashing the mantis a second time
       Burrow, Sword OR Shuriken=3
+      Burrow, SentryJump=1
 
   conn UpperWastes.NorthTP:
     moki: Burrow

--- a/areas.wotw
+++ b/areas.wotw
@@ -10273,6 +10273,9 @@ anchor EastPools.CentralRoom at -1485, -4148:  # The room where you meet Kwolok 
     unsafe:
       EastPools.CentralRoomBubbleFree, Bash, DoubleJump, Blaze=1
       EastPools.CentralRoomBubbleFree, Bash, Grenade=1  # bashnade from the seed to jump on the bubble then wait another bubble
+      EastPools.CentralRoomBubbleFree, SentryJump=1  # sjump from GrassSeed
+      EastPools.CentralRoomBubbleFree, GrenadeJump, DoubleJump OR Glide  # grenade jump on the bubble, use the other ability to stall, repeat until at the top
+      SentryJump=2  # sjump to GrassSeed, sjump from GrassSeed
   conn WestPools:
     moki: Water, WaterBreath, WaterDash, DoubleJump OR Dash OR Glide OR Launch
     gorlek: Water, WaterDash, DoubleJump OR Dash OR Glide OR Launch OR Sword OR Hammer OR Damage=20

--- a/areas.wotw
+++ b/areas.wotw
@@ -775,6 +775,8 @@ anchor HowlsDen.AboveBoneBridge at -446, -4436:  # After the climb up through th
       Bash, Grenade=1
     kii:
       Bash
+    unsafe:
+      SentryJump=1
 
   conn HowlsDen.UpperLoopEntrance: free
   conn HowlsDen.Entrance:
@@ -787,6 +789,7 @@ anchor HowlsDen.AboveBoneBridge at -446, -4436:  # After the climb up through th
     unsafe, MarshSpawn.HowlBurnt:
       Bash, DoubleJump OR Dash OR Glide OR Sword  # use the slime
       Bash  # use the slime, tight coyote jump
+      SentryJump=1
   conn HowlsDen.SecretRoom:
     gorlek: ShurikenBreak=16, BreakWall=20
     unsafe:
@@ -810,6 +813,7 @@ anchor HowlsDen.UpperLoopEntrance at -407, -4451:  # In front of the bone door b
       DoubleJump, TripleJump
     kii:
       DoubleJump, Hammer  # kinda pointless with hammer but a path is a path
+    # If you can sentry jump, you can take the normal path
   conn HowlsDen.UpperLoopExit:
     moki:
       BreakWall=16, BreakWall=16, Combat=Slug, DoubleJump OR Dash
@@ -905,7 +909,9 @@ anchor HowlsDen.BoneBridge at -371, -4468:  # After the long drop into Howl's De
       Sword OR Hammer
       BreakWall=16, Damage=10, Shuriken=5 OR Sentry=5 OR Flash=5  # one jump is kinda hard
       BreakWall=16, Sentry=6  # two sentries in the air to avoid the spikes
-    unsafe: Bash, Glide OR DoubleJump  # Climbing with mantis (bashing enemy up and jump/glide directly afterwards) (glide can be buffered)
+    unsafe:
+      Bash, Glide OR DoubleJump  # Climbing with mantis (bashing enemy up and jump/glide directly afterwards) (glide can be buffered)
+      SentryJump=2
   conn HowlsDen.Teleporter:
     moki: HowlsDen.BoneBarrier
 
@@ -9471,8 +9477,9 @@ anchor PoolsApproach.OnTopOfWheel at -971, -4164:  # Highest point on the wheel
       PoolsApproach.WheelFreed, Dash, Hammer
     unsafe:
       GlideJump, DoubleJump OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      SwordJump
+      SwordJump OR HammerJump
       GrenadeJump, GrenadeCancel  # gjump to reach the platform then cancel second one to the pickup, cancel it and grenade float (which you also need to cancel so you can wjump)
+      SentryJump=1
   pickup PoolsApproach.CurrentEX:
     moki: Water, WaterDash
     kii: Damage=100, WaterDash

--- a/areas.wotw
+++ b/areas.wotw
@@ -2473,7 +2473,8 @@ anchor EastHollow.AfterBeetleFight at -28, -4233:  # At the breakable floor to B
       DoubleJump, TripleJump, Dash
       Bash  # Go to the right to make the mantis spawn if it's not here
     unsafe:
-      DoubleJump, SentryJump=1 OR Dash
+      DoubleJump, SentryJump=1 OR Dash  # @validator How does dash work here?
+      SentryJump=2  # dodge the spikes with the weapon you use to sjump
   pickup EastHollow.SecretRoofEX:
     moki:
       Bash OR Launch

--- a/areas.wotw
+++ b/areas.wotw
@@ -9986,6 +9986,7 @@ anchor EastPools.TPArea at -1297, -4143:  # Where Tokk stands
     unsafe:
       Grapple, Damage=40
       DoubleJump, TripleJump
+      SentryJump=1
   conn EastPools.WaterdashArena:
     moki, EastPools.ArenaWall: Water
   conn EastPools.BelowTokk: free
@@ -10067,6 +10068,7 @@ anchor EastPools.FishingPool at -1278, -4124:  # At the fisher moki
       Bash, Grenade=1
       WaterDash, Hammer, Water OR Damage=20
       DoubleJump, TripleJump  # ceiling jump on the wall above the fishing pond
+      SentryJump=1
   conn EastPools.TPArea: free
 
 anchor EastPools.AboveFishingPool at -1300, -4102:  # Above the fishing Moki
@@ -10679,7 +10681,7 @@ anchor UpperPools.AboveTree at -1450, -4053:  # Paths to simplify the xp pickup 
     gorlek: Sword OR Hammer
     kii: Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
 
-anchor UpperPools.DrainPuzzleEntrance at -1313, -4083:  # At the right of the door opened by the water dash button in the tree room
+anchor UpperPools.DrainPuzzleEntrance at -1386, -4062:  # At the right of the door opened by the water dash button in the tree room
   refill Checkpoint
 
   # Be careful because solving that puzzle room is a huuuge negative that has to be taken into account


### PR DESCRIPTION
A bunch of unorganized paths based off of logical gaps I noticed while playing. All of them have been marked as unsafe.

Notable Additions:
- some dirty swim paths in the area between Kwolok's Hollow and the Silent Woods
- a really difficult and time-consuming path involving pause floats in `EastPools.CentralRoom` that took like half an hour to do
- `UpperPools.DrainPuzzleEntrance` has been moved, the coordinates previously put it on top of `UpperPools.DrainPuzzleExit`
- a lot of sentry jump paths