### PR TITLE
Flash swap escapes

### DIFF
--- a/areas.wotw
+++ b/areas.wotw
@@ -5683,6 +5683,7 @@ anchor InnerWellspring.EscapeSequence at -1240, -3642:
       Grapple, Bash, WaterDash, Damage=80
       Grapple, Bash, Hammer
       Grapple, DoubleJump
+      FlashSwap
 
   pickup InnerWellspring.EscapeRevisitEX:
     moki: InnerWellspring.WaterEscape

--- a/areas.wotw
+++ b/areas.wotw
@@ -8955,6 +8955,7 @@ anchor MoraEscape at 712, -4482:
     unsafe:
       Bash, Grapple
       Launch
+      FlashSwap # Yes, it works on hard mode.
   
 anchor MoraSecondPhase at 690, -4386:
   nospawn

--- a/areas.wotw
+++ b/areas.wotw
@@ -7705,6 +7705,8 @@ anchor LowerReach.ArenaArea at 44, -3992:  # To the left of the combat arena
     kii, LowerReach.ArenaBeaten:
       Launch
       DoubleJump, TripleJump
+    unsafe, LowerReach.ArenaBeaten:
+      FlashSwap
   conn LowerReach.SwimmingPool:
     moki, LowerReach.EastDoorLantern:
       LowerReach.FreezeEastFurnace OR Water
@@ -7742,6 +7744,8 @@ anchor LowerReach.WindSpinners at 73,-3929:  # midway through the wind column ab
       Launch, Spear=1 OR Shuriken=1 OR Sentry=1 OR Spear=1 OR Flash=1  # Pass under the first spinner and launch to the wall above it
       DoubleJump, TripleJump, Damage=20
       Bash, Grenade=1, DoubleJump, TripleJump  # Precise grenade throw above the first spinner, pass under the spinner to catch the grenade and bash glide to the right wall
+      FlashSwap
+      Launch  # There are multiple ways to do this, and all of them look awesome.
   conn LowerReach.ArenaArea:
     moki: Glide, LowerReach.ArenaBeaten
     gorlek: LowerReach.ArenaBeaten
@@ -7792,6 +7796,8 @@ anchor LowerReach.LowerWispPath at 83, -3874:  # At the checkpoint just after th
       Bash, DoubleJump, TripleJump, Damage=20
       Bash, SwordSJump=1
       Bash, HammerSJump=1, Glide OR DoubleJump OR Dash
+      FlashSwap
+      LaunchSwap
   conn LowerReach.WindSpinners:
     moki: Glide
     gorlek: Launch, Damage=20
@@ -7821,6 +7827,8 @@ anchor LowerReach.BridgeWispPath at 67, -3808:  # At the bridge checkpoint, next
     unsafe:
       Bash, DoubleJump OR Dash OR Grapple OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       DoubleJump, TripleJump, Shuriken=2
+      FlashSwap
+      Launch
   conn LowerReach.LowerWispPath:
     moki:
       Bash
@@ -7877,6 +7885,7 @@ anchor LowerReach.SnowEscape at 79, -3733:
       SentryJump=2, DoubleJump, Dash  # 1st sjump on a friendly spike and 2nd one on the branch to pass the 1st wind column
       SentryJump=3, Dash, Grapple OR Damage=20
       Dash, SentryJump=4
+      FlashSwap  # Dodging the water is scary but totally doable.
 
   pickup LowerReach.EscapeRevisitEX:
     moki: LowerReach.ForestsMemory
@@ -7975,7 +7984,9 @@ anchor LowerReach.TrialStart at 64, -4045:  # At trial start
       Bash, Grenade=1, Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1 OR Damage=10
   conn LowerReach.ArenaArea:
     moki: LowerReach.ArenaBeaten, Glide
-    unsafe: LowerReach.ArenaBeaten, Launch  # Launch Swap
+    unsafe, LowerReach.ArenaBeaten:
+      Launch  # Launch Swap
+      FlashSwap
 
 region UpperReach:
   moki: Danger=40, Regenerate

--- a/areas.wotw
+++ b/areas.wotw
@@ -7853,6 +7853,7 @@ anchor LowerReach.SnowEscape at 79, -3733:
       SentryJump=2, DoubleJump, Dash  # 1st sjump on a friendly spike and 2nd one on the branch to pass the 1st wind column
       SentryJump=3, Dash, Grapple OR Damage=20
       Dash, SentryJump=4
+      FlashSwap  # Dodging the water is scary but totally doable.
 
   state LowerReach.BearSneezed:  # Same paths as LowerReach.ForestsMemory (when finishing the escape, Baur isn't blocking the Reach entrance anymore)
     moki:

--- a/areas.wotw
+++ b/areas.wotw
@@ -12668,6 +12668,7 @@ anchor WindtornRuins.Escape at 2021, -4026:
       Burrow, Grapple, Damage=10  # You are allowed to hate me if this is forced progression https://youtu.be/H3UIH4FyU4Q
       Burrow, Grapple, Blaze=5 OR Flash=5
       Burrow, Dash, Damage=40, Sentry=1 OR Flash=1
+      Burrow, FlashSwap
 
 anchor WindtornRuins.LowerRuins at 1969, -4024:  # At the ancient map pedestal
   # requires escape to be done

--- a/areas.wotw
+++ b/areas.wotw
@@ -5645,6 +5645,10 @@ anchor InnerWellspring.Teleporter at -1308, -3675:  # At the teleporter
       Dash, Hammer, Grapple
     unsafe:
       Dash OR DoubleJump OR SentryJump=1
+      FlashSwap OR BlazeSwap=2 OR SentrySwap=2 # Jump from the top of the stairs and climb the left wall.
+      BlazeSwap=1 OR SentrySwap=1:
+        Sword OR Hammer OR Shuriken=1 OR Spear=1 OR Glide OR Flash=1 OR PauseHover # Yep, difficult Blaze/Sentry swap and then Flash hop. Why not.
+      GrenadeJump
 
 # checkpoint at -1249, -3641
 


### PR DESCRIPTION
A set of paths using only Flash swaps for all of the escapes except for Kwolok (I don't really want to mess with that until the rubberbanding fix gets released) and Shriek (out of logic in general). All of them have been verified in hard mode.

Also includes a few ability-swap-related paths on the way to the Wellspring and Avalanche escapes.